### PR TITLE
feat: add path, line, and commit_id metadata to thread output

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ gh pr-reviews --all
 
 JSON array of review comments with classification and resolution status.
 
-There are two types: `thread` (inline review thread) and `comment` (PR-level comment). `thread_id` is only present for `thread` type. `comment_id` is the REST API comment ID, which can be used for replying.
+There are two types: `thread` (inline review thread) and `comment` (PR-level comment). `thread_id`, `path`, `line`, and `commit_id` are only present for `thread` type. `comment_id` is the REST API comment ID, which can be used for replying.
 
 ```json
 [
@@ -32,6 +32,9 @@ There are two types: `thread` (inline review thread) and `comment` (PR-level com
     "thread_id": "PRRT_kwDOH7hXo85vAD-t",
     "comment_id": 2815812186,
     "type": "thread",
+    "path": "src/handler.go",
+    "line": 42,
+    "commit_id": "abc1234def5678",
     "author": "reviewer",
     "body": "This should use error wrapping",
     "url": "https://github.com/owner/repo/pull/123#discussion_r123456",

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -43,6 +43,9 @@ type reviewThreadsQuery struct {
 							Author     struct{ Login string }
 							CreatedAt  time.Time
 							URL        string `graphql:"url"`
+							Commit     struct {
+								Oid string
+							}
 						}
 					} `graphql:"comments(first: 100)"`
 				}
@@ -108,6 +111,7 @@ func (c *Client) FetchReviews(ctx context.Context, owner, repo string, number in
 					Author:     c.Author.Login,
 					CreatedAt:  c.CreatedAt,
 					URL:        c.URL,
+					CommitID:   c.Commit.Oid,
 				})
 			}
 			data.Threads = append(data.Threads, thread)

--- a/review/review.go
+++ b/review/review.go
@@ -14,6 +14,7 @@ type Comment struct {
 	Author     string    `json:"author"`
 	CreatedAt  time.Time `json:"created_at"`
 	URL        string    `json:"url"`
+	CommitID   string    `json:"commit_id,omitempty"`
 }
 
 // Thread represents an inline review thread.
@@ -28,18 +29,18 @@ type Thread struct {
 
 // Data holds all review data for a PR.
 type Data struct {
-	Threads    []Thread `json:"threads"`
-	PRComments []Comment      `json:"pr_comments"`
+	Threads    []Thread  `json:"threads"`
+	PRComments []Comment `json:"pr_comments"`
 }
 
 // ClassifyInputThread is a thread entry sent to the classifier.
 type ClassifyInputThread struct {
-	ThreadID            string                `json:"thread_id"`
-	Type                string                `json:"type"`
-	Path                string                `json:"path,omitempty"`
-	Line                *int                  `json:"line,omitempty"`
-	IsResolvedOnGitHub  bool                  `json:"is_resolved_on_github"`
-	Comments            []ClassifyInputComment `json:"comments"`
+	ThreadID           string                 `json:"thread_id"`
+	Type               string                 `json:"type"`
+	Path               string                 `json:"path,omitempty"`
+	Line               *int                   `json:"line,omitempty"`
+	IsResolvedOnGitHub bool                   `json:"is_resolved_on_github"`
+	Comments           []ClassifyInputComment `json:"comments"`
 }
 
 // ClassifyInputComment is a comment entry sent to the classifier.
@@ -96,6 +97,9 @@ type UnresolvedComment struct {
 	ThreadID  string `json:"thread_id,omitempty"`
 	CommentID int64  `json:"comment_id"`
 	Type      string `json:"type"`
+	Path      string `json:"path,omitempty"`
+	Line      *int   `json:"line,omitempty"`
+	CommitID  string `json:"commit_id,omitempty"`
 	Author    string `json:"author"`
 	Body      string `json:"body"`
 	URL       string `json:"url"`
@@ -179,19 +183,23 @@ func buildResults(data *Data, output *ClassifyOutput, showAll bool) []Unresolved
 		}
 
 		// Use the first comment as the representative.
-		var author, body, url string
+		var author, body, url, commitID string
 		var commentID int64
 		if len(t.Comments) > 0 {
 			author = t.Comments[0].Author
 			body = t.Comments[0].Body
 			url = t.Comments[0].URL
 			commentID = t.Comments[0].DatabaseID
+			commitID = t.Comments[0].CommitID
 		}
 
 		results = append(results, UnresolvedComment{
 			ThreadID:  t.ID,
 			CommentID: commentID,
 			Type:      "thread",
+			Path:      t.Path,
+			Line:      t.Line,
+			CommitID:  commitID,
 			Author:    author,
 			Body:      body,
 			URL:       url,


### PR DESCRIPTION
Fetch commit OID from GraphQL PullRequestReviewComment and include path, line, and commit_id fields in thread-type output for richer context about where each review comment was made.