### PR TITLE
feat: add diff_hunk metadata to thread output

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ gh pr-reviews --all
 
 JSON array of review comments with classification and resolution status.
 
-There are two types: `thread` (inline review thread) and `comment` (PR-level comment). `thread_id`, `path`, `line`, and `commit_id` are only present for `thread` type. `comment_id` is the REST API comment ID, which can be used for replying.
+There are two types: `thread` (inline review thread) and `comment` (PR-level comment). `thread_id`, `path`, `line`, `commit_id`, and `diff_hunk` are only present for `thread` type. `comment_id` is the REST API comment ID, which can be used for replying.
 
 ```json
 [
@@ -35,6 +35,7 @@ There are two types: `thread` (inline review thread) and `comment` (PR-level com
     "path": "src/handler.go",
     "line": 42,
     "commit_id": "abc1234def5678",
+    "diff_hunk": "@@ -40,6 +40,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {\n \tif err != nil {\n-\t\tlog.Println(err)\n+\t\treturn err",
     "author": "reviewer",
     "body": "This should use error wrapping",
     "url": "https://github.com/owner/repo/pull/123#discussion_r123456",

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -43,6 +43,7 @@ type reviewThreadsQuery struct {
 							Author     struct{ Login string }
 							CreatedAt  time.Time
 							URL        string `graphql:"url"`
+							DiffHunk   string
 							Commit     struct {
 								Oid string
 							}
@@ -111,6 +112,7 @@ func (c *Client) FetchReviews(ctx context.Context, owner, repo string, number in
 					Author:     c.Author.Login,
 					CreatedAt:  c.CreatedAt,
 					URL:        c.URL,
+					DiffHunk:   c.DiffHunk,
 					CommitID:   c.Commit.Oid,
 				})
 			}

--- a/review/review.go
+++ b/review/review.go
@@ -14,6 +14,7 @@ type Comment struct {
 	Author     string    `json:"author"`
 	CreatedAt  time.Time `json:"created_at"`
 	URL        string    `json:"url"`
+	DiffHunk   string    `json:"diff_hunk,omitempty"`
 	CommitID   string    `json:"commit_id,omitempty"`
 }
 
@@ -100,6 +101,7 @@ type UnresolvedComment struct {
 	Path      string `json:"path,omitempty"`
 	Line      *int   `json:"line,omitempty"`
 	CommitID  string `json:"commit_id,omitempty"`
+	DiffHunk  string `json:"diff_hunk,omitempty"`
 	Author    string `json:"author"`
 	Body      string `json:"body"`
 	URL       string `json:"url"`
@@ -183,7 +185,7 @@ func buildResults(data *Data, output *ClassifyOutput, showAll bool) []Unresolved
 		}
 
 		// Use the first comment as the representative.
-		var author, body, url, commitID string
+		var author, body, url, commitID, diffHunk string
 		var commentID int64
 		if len(t.Comments) > 0 {
 			author = t.Comments[0].Author
@@ -191,6 +193,7 @@ func buildResults(data *Data, output *ClassifyOutput, showAll bool) []Unresolved
 			url = t.Comments[0].URL
 			commentID = t.Comments[0].DatabaseID
 			commitID = t.Comments[0].CommitID
+			diffHunk = t.Comments[0].DiffHunk
 		}
 
 		results = append(results, UnresolvedComment{
@@ -200,6 +203,7 @@ func buildResults(data *Data, output *ClassifyOutput, showAll bool) []Unresolved
 			Path:      t.Path,
 			Line:      t.Line,
 			CommitID:  commitID,
+			DiffHunk:  diffHunk,
 			Author:    author,
 			Body:      body,
 			URL:       url,


### PR DESCRIPTION
This pull request adds support for including the `diff_hunk` field in review thread comments, enabling downstream consumers to access the specific diff context for each comment. The changes update the data model, GraphQL query, and output format to ensure that `diff_hunk` is available and properly serialized in the review results.

**Data model and serialization updates:**
- Added a `DiffHunk` field to the `Comment` and `UnresolvedComment` structs in `review/review.go`, ensuring that diff context is included in serialized output. [[1]](diffhunk://#diff-2b20e8e28a21d5069a7110abff0326d2aa6bea65a705d518c397ef45e9ab2249R17) [[2]](diffhunk://#diff-2b20e8e28a21d5069a7110abff0326d2aa6bea65a705d518c397ef45e9ab2249R104)
- Updated the `buildResults` function in `review/review.go` to extract and include the `diff_hunk` from the first comment in each thread when constructing unresolved comments. [[1]](diffhunk://#diff-2b20e8e28a21d5069a7110abff0326d2aa6bea65a705d518c397ef45e9ab2249L186-R196) [[2]](diffhunk://#diff-2b20e8e28a21d5069a7110abff0326d2aa6bea65a705d518c397ef45e9ab2249R206)

**GraphQL and data fetching changes:**
- Modified the GraphQL query in `gh/gh.go` to request the `DiffHunk` field for review comments, and updated the mapping logic to include it in the returned data. [[1]](diffhunk://#diff-1e114263bdcb1a392f7956eeabd73e7df043db8186b943bbd1a3e0ab78762cceR46) [[2]](diffhunk://#diff-1e114263bdcb1a392f7956eeabd73e7df043db8186b943bbd1a3e0ab78762cceR115)

**Documentation update:**
- Updated the `README.md` to document the new `diff_hunk` field in the JSON output for review comments, and provided an example of its usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R27) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38)