### PR TITLE
feat: add shell completion for --copilot-model flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -209,6 +209,14 @@ func init() {
 	rootCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results as JSON")
 	rootCmd.Flags().IntVarP(&widthFlag, "width", "w", 0, "Output width (0 for auto-detect)")
 
+	_ = rootCmd.RegisterFlagCompletionFunc("copilot-model", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		models, err := review.ListCopilotModels(rootCmd.Context())
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		return models, cobra.ShellCompDirectiveNoFileComp
+	})
+
 	// Hide the default completion command.
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 

--- a/review/copilot.go
+++ b/review/copilot.go
@@ -214,6 +214,33 @@ func parseClassifyOutput(raw string) (*ClassifyOutput, error) {
 	return &output, nil
 }
 
+// ListCopilotModels returns available model IDs from the Copilot SDK.
+func ListCopilotModels(ctx context.Context) ([]string, error) {
+	if err := checkCopilotCLI(); err != nil {
+		return nil, err
+	}
+
+	client := copilot.NewClient(&copilot.ClientOptions{
+		LogLevel: "error",
+	})
+
+	if err := client.Start(ctx); err != nil {
+		return nil, fmt.Errorf("failed to start copilot client: %w", err)
+	}
+	defer client.Stop() //nolint:errcheck
+
+	models, err := client.ListModels(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list models: %w", err)
+	}
+
+	ids := make([]string, 0, len(models))
+	for _, m := range models {
+		ids = append(ids, m.ID)
+	}
+	return ids, nil
+}
+
 func truncate(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s


### PR DESCRIPTION
This pull request adds support for shell autocompletion of the `--copilot-model` flag by dynamically fetching available model IDs from the Copilot SDK. The main changes include implementing a new function to list Copilot models and registering a flag completion function in the CLI.

**Shell Autocompletion Improvements:**

* Added a flag completion function for the `--copilot-model` flag in `cmd/root.go`, enabling dynamic shell autocompletion with available Copilot model IDs.

**Copilot SDK Integration:**

* Implemented the `ListCopilotModels` function in `review/copilot.go` to query the Copilot SDK for available model IDs, handling client lifecycle and error cases.