### PR TITLE
feat: change default copilot model to claude-haiku-4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ $ gh extension install k1LoW/gh-pr-reviews
 | `--all` | `-a` | Show all review comments including resolved ones |
 | `--json` | | Output results as JSON |
 | `--width` | `-w` | Output width (0 for auto-detect, default: auto) |
-| `--copilot-model` | | Copilot model to use for classification (default: `gpt-4o`) |
+| `--copilot-model` | | Copilot model to use for classification (default: `claude-haiku-4.5`) |
 | `--verbose` | | Verbose output |
 
 ## Contributing

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -204,7 +204,7 @@ func Execute() {
 func init() {
 	rootCmd.Flags().StringVarP(&flagRepoSelector, "repo", "R", "", "Select another repository using the [HOST/]OWNER/REPO format")
 	rootCmd.Flags().BoolVarP(&showAll, "all", "a", false, "Show all review comments including resolved ones")
-	rootCmd.Flags().StringVar(&copilotModel, "copilot-model", "gpt-4o", "Copilot model to use for classification")
+	rootCmd.Flags().StringVar(&copilotModel, "copilot-model", "claude-haiku-4.5", "Copilot model to use for classification")
 	rootCmd.Flags().BoolVar(&verbose, "verbose", false, "Verbose output")
 	rootCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output results as JSON")
 	rootCmd.Flags().IntVarP(&widthFlag, "width", "w", 0, "Output width (0 for auto-detect)")


### PR DESCRIPTION
This pull request updates the default Copilot model used for classification from `gpt-4o` to `claude-haiku-4.5`. The change is reflected in both the command-line flag definition and the documentation.

Configuration and documentation updates:

* Changed the default value of the `--copilot-model` flag in `cmd/root.go` to `claude-haiku-4.5` instead of `gpt-4o`.
* Updated the `README.md` to indicate the new default Copilot model as `claude-haiku-4.5`.