### PR TITLE
docs: add Claude Code Skill example for triaging PR review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,55 @@ $ gh extension install k1LoW/gh-pr-reviews
 | `--copilot-model` | | Copilot model to use for classification (default: `claude-haiku-4.5`) |
 | `--verbose` | | Verbose output |
 
+## Claude Code Skill Example
+
+You can use `gh pr-reviews` as part of a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) custom slash command (Skill). Below is an example skill that triages unresolved review comments by analyzing code context and classifying each comment as Agree / Partially Agree / Disagree.
+
+Copy the content below into your project's `.claude/skills/triage-pr-reviews/SKILL.md` (or `~/.claude/skills/triage-pr-reviews/SKILL.md` for global use). The directory name becomes the slash command, so this skill is invoked as `/triage-pr-reviews` in Claude Code.
+
+````markdown
+# Triage PR Review Comments
+1. Run `gh pr-reviews [arg] --json` to get unresolved review comments as JSON. If no argument is given, use the current branch's PR. Note: this command uses Copilot for classification and may take a while depending on the number of comments — use a longer timeout. Each JSON object contains:
+   - `comment_id` (int): REST API comment ID — usable for replying via `gh api`
+   - `thread_id` (string, only for `type: "thread"`): inline review thread ID
+   - `type`: `"thread"` (inline review) or `"comment"` (PR-level)
+   - `author`, `body`, `url`: comment metadata
+   - `commit_id`, `path`, `line`, `diff_hunk` (only for `type: "thread"`): file location and diff context
+   - `category`: one of `suggestion`, `nitpick`, `issue`, `question`, `approval`, `informational`
+   - `resolved` (bool), `reason` (string): resolution status and rationale
+2. Check if PR metadata (number, title, url) is already available from conversation context. If not (e.g., when a PR number/URL is explicitly passed as argument), run `gh pr view [arg] --json number,title,url` to get it.
+3. For `type: "thread"` comments, use `path`, `line`, and `diff_hunk` from the JSON response to identify the exact file location. For `type: "comment"` (PR-level), there is no file location.
+4. Check code context for each comment. Leverage any existing conversation context first. Only fetch additional context via `gh pr diff` or file reads when necessary.
+5. Evaluate each comment against the code context. Classify as **Agree**, **Partially Agree**, or **Disagree** with a rationale and suggested action.
+6. Output results in this format:
+
+```
+## Unresolved Review Comments Analysis
+
+**PR**: #<number> (<title>)
+**Unresolved comments**: <count>
+
+---
+
+### Comment 1 — [<category>] by @<author>
+> <comment body>
+
+**File**: `<path>` (line <line>)
+**Assessment**: Agree | Partially Agree | Disagree
+**Rationale**: <1-3 sentences>
+**Suggested action**: <recommended action>
+
+---
+
+## Summary
+- Agree: n — should be addressed
+- Partially Agree: n — worth discussing
+- Disagree: n — can be explained or dismissed
+```
+
+Do NOT write to GitHub (no commenting, resolving, or any mutations). Do NOT commit or push. If code context is unclear, use Grep to verify before making a judgment. Prefer `gh` commands over WebFetch for GitHub data.
+````
+
 ## Contributing
 
 To use this project from source, instead of a release:


### PR DESCRIPTION
This pull request adds documentation to the `README.md` describing how to use the `gh pr-reviews` tool as part of a Claude Code custom skill. The new section provides a detailed example and step-by-step instructions for integrating review comment triage into Claude Code workflows.

Documentation improvements:

* Added a "Claude Code Skill Example" section to `README.md`, including a ready-to-use skill definition for triaging PR review comments with `gh pr-reviews` in Claude Code, along with usage instructions and output format.