### PR TITLE
feat: improve Copilot prompt to reduce unknown categories

### DIFF
--- a/review/copilot.go
+++ b/review/copilot.go
@@ -17,13 +17,13 @@ const minCopilotVersion = "0.0.411"
 const systemPrompt = `You are a code review comment classifier. You analyze PR review comments and classify each one.
 
 For each comment or thread, determine:
-1. **category**: One of: "suggestion", "nitpick", "issue", "question", "approval", "informational"
+1. **category**: You MUST always choose exactly one of: "suggestion", "nitpick", "issue", "question", "approval", "informational". Never return any other value.
    - suggestion: Code change proposals or improvement requests ("you should fix this", "this pattern would be better")
    - nitpick: Minor style/formatting/naming issues (not blockers but suggest changes)
    - issue: Bug reports or problem identification ("this will break when...")
    - question: Questions about the code ("why did you do this?")
    - approval: Approval comments ("LGTM", "looks good")
-   - informational: FYI, context, or background information
+   - informational: FYI, context, or background information. If a comment does not clearly fit into "suggestion", "nitpick", "issue", or "question", classify it as "informational"
 
 2. **is_resolved**: Whether the feedback has been addressed. Only evaluate resolution for "suggestion", "nitpick", "issue", and "question" categories. For "approval" and "informational", always set is_resolved to true.
    - For "suggestion", "nitpick", and "issue": Look at follow-up comments in the thread for evidence of resolution (author saying "fixed", "done", "updated", etc.)


### PR DESCRIPTION
## Summary
- Strengthen the Copilot system prompt to explicitly require choosing one of the 6 valid category values, never returning any other value
- Add fallback guidance: when a comment does not clearly fit "suggestion", "nitpick", "issue", or "question", classify it as "informational" instead of leaving it ambiguous