### PR TITLE
feat: add OnPermissionRequest handler to Copilot session config

### DIFF
--- a/review/copilot.go
+++ b/review/copilot.go
@@ -63,7 +63,8 @@ func NewCopilotClassifier(ctx context.Context, model string) (*CopilotClassifier
 	}
 
 	session, err := client.CreateSession(ctx, &copilot.SessionConfig{
-		Model: model,
+		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
+		Model:               model,
 		SystemMessage: &copilot.SystemMessageConfig{
 			Content: systemPrompt,
 		},


### PR DESCRIPTION
## Summary
- Add required `OnPermissionRequest: copilot.PermissionHandler.ApproveAll` to `SessionConfig` to fix session creation failure with Copilot SDK v0.1.30