### PR TITLE
fix: improve thread conversation analysis for resolution detection

### DIFF
--- a/output/markdown.go
+++ b/output/markdown.go
@@ -146,6 +146,16 @@ func renderComment(w io.Writer, c review.UnresolvedComment, p *termenv.Output, w
 	// Body.
 	fmt.Fprintln(w, wordwrap.String(c.Body, width))
 
+	// Replies.
+	for _, r := range c.Replies {
+		fmt.Fprintln(w)
+		replyHeader := p.String(fmt.Sprintf("> **@%s**:", r.Author)).Faint()
+		fmt.Fprintln(w, replyHeader)
+		for _, line := range strings.Split(wordwrap.String(r.Body, width-2), "\n") {
+			fmt.Fprintln(w, p.String("> "+line).Faint())
+		}
+	}
+
 }
 
 func categoryColor(category string) string {

--- a/output/markdown.go
+++ b/output/markdown.go
@@ -151,7 +151,7 @@ func renderComment(w io.Writer, c review.UnresolvedComment, p *termenv.Output, w
 		fmt.Fprintln(w)
 		replyHeader := p.String(fmt.Sprintf("> **@%s**:", r.Author)).Faint()
 		fmt.Fprintln(w, replyHeader)
-		for _, line := range strings.Split(wordwrap.String(r.Body, width-2), "\n") {
+		for _, line := range strings.Split(wordwrap.String(r.Body, max(width-2, 1)), "\n") {
 			fmt.Fprintln(w, p.String("> "+line).Faint())
 		}
 	}

--- a/output/markdown_test.go
+++ b/output/markdown_test.go
@@ -219,6 +219,69 @@ func TestRenderMarkdownNoLine(t *testing.T) {
 	}
 }
 
+func TestRenderMarkdownReplies(t *testing.T) {
+	line := 42
+	results := []review.UnresolvedComment{
+		{
+			ThreadID: "t1",
+			Type:     "thread",
+			Path:     "src/main.go",
+			Line:     &line,
+			Author:   "alice",
+			Body:     "Why is this needed?",
+			URL:      "https://github.com/example/1",
+			Category: "question",
+			Resolved: false,
+			Replies: []review.ReplyComment{
+				{
+					Author: "bob",
+					Body:   "It handles the edge case for empty input.",
+					URL:    "https://github.com/example/2",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	RenderMarkdown(&buf, results, newTestOutput(), 80)
+	out := buf.String()
+
+	if !strings.Contains(out, "@bob") {
+		t.Error("missing reply author @bob")
+	}
+	if !strings.Contains(out, "edge case for empty input") {
+		t.Error("missing reply body")
+	}
+	if !strings.Contains(out, ">") {
+		t.Error("missing blockquote prefix for reply")
+	}
+}
+
+func TestRenderMarkdownNoReplies(t *testing.T) {
+	results := []review.UnresolvedComment{
+		{
+			Type:     "comment",
+			Author:   "alice",
+			Body:     "Just a comment",
+			URL:      "https://github.com/example/1",
+			Category: "suggestion",
+			Resolved: false,
+		},
+	}
+
+	var buf bytes.Buffer
+	RenderMarkdown(&buf, results, newTestOutput(), 80)
+	out := buf.String()
+
+	// Should not contain reply blockquote markers beyond the body.
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "> ") {
+			t.Errorf("unexpected blockquote line in output without replies: %q", line)
+		}
+	}
+}
+
 func TestRenderMarkdownWordWrap(t *testing.T) {
 	results := []review.UnresolvedComment{
 		{

--- a/review/copilot.go
+++ b/review/copilot.go
@@ -16,6 +16,8 @@ const minCopilotVersion = "0.0.411"
 
 const systemPrompt = `You are a code review comment classifier. You analyze PR review comments and classify each one.
 
+IMPORTANT: Each thread contains a "comments" array listing the full conversation in chronological order. The first comment is the original review comment; subsequent comments are replies. You MUST read ALL comments in every thread before classifying. The conversation flow is critical for determining resolution status.
+
 For each comment or thread, determine:
 1. **category**: You MUST always choose exactly one of: "suggestion", "nitpick", "issue", "question", "approval", "informational". Never return any other value.
    - suggestion: Code change proposals or improvement requests ("you should fix this", "this pattern would be better")
@@ -26,11 +28,13 @@ For each comment or thread, determine:
    - informational: FYI, context, or background information. If a comment does not clearly fit into "suggestion", "nitpick", "issue", or "question", classify it as "informational"
 
 2. **is_resolved**: Whether the feedback has been addressed. Only evaluate resolution for "suggestion", "nitpick", "issue", and "question" categories. For "approval" and "informational", always set is_resolved to true.
-   - For "suggestion", "nitpick", and "issue": Look at follow-up comments in the thread for evidence of resolution (author saying "fixed", "done", "updated", etc.)
-   - For "question": Look at follow-up comments for evidence that the question has been answered. If the question remains unanswered, set is_resolved to false.
+   - For threads with multiple comments, you MUST analyze the ENTIRE conversation to determine resolution:
+     - For "suggestion", "nitpick", and "issue": A reply from the PR author acknowledging the feedback (e.g., "fixed", "done", "updated", explaining the change, or providing a valid justification for the current approach) indicates resolution.
+     - For "question": Any substantive reply that answers the question indicates resolution. This includes explanations, clarifications, or references to relevant context. A question that has received a meaningful answer MUST be marked as resolved.
    - If is_resolved_on_github is true, always consider it resolved regardless of comment content.
+   - Only set is_resolved to false when there is NO meaningful reply addressing the concern, or when there is an ongoing unresolved disagreement after the latest reply.
 
-3. **reason**: Brief explanation of your classification and resolution decision.
+3. **reason**: Brief explanation of your classification and resolution decision. When a thread has multiple comments, reference the relevant reply that influenced your decision.
 
 You will receive a JSON object with "threads" (inline review threads) and "pr_comments" (top-level PR comments).
 

--- a/review/review.go
+++ b/review/review.go
@@ -93,21 +93,30 @@ type CommentClassifier interface {
 	Close()
 }
 
+// ReplyComment represents a follow-up comment in a thread.
+type ReplyComment struct {
+	Author    string    `json:"author"`
+	Body      string    `json:"body"`
+	CreatedAt time.Time `json:"created_at"`
+	URL       string    `json:"url"`
+}
+
 // UnresolvedComment is the JSON output structure for CLI results.
 type UnresolvedComment struct {
-	ThreadID  string `json:"thread_id,omitempty"`
-	CommentID int64  `json:"comment_id"`
-	Type      string `json:"type"`
-	Path      string `json:"path,omitempty"`
-	Line      *int   `json:"line,omitempty"`
-	CommitID  string `json:"commit_id,omitempty"`
-	DiffHunk  string `json:"diff_hunk,omitempty"`
-	Author    string `json:"author"`
-	Body      string `json:"body"`
-	URL       string `json:"url"`
-	Category  string `json:"category"`
-	Resolved  bool   `json:"resolved"`
-	Reason    string `json:"reason"`
+	ThreadID  string         `json:"thread_id,omitempty"`
+	CommentID int64          `json:"comment_id"`
+	Type      string         `json:"type"`
+	Path      string         `json:"path,omitempty"`
+	Line      *int           `json:"line,omitempty"`
+	CommitID  string         `json:"commit_id,omitempty"`
+	DiffHunk  string         `json:"diff_hunk,omitempty"`
+	Author    string         `json:"author"`
+	Body      string         `json:"body"`
+	URL       string         `json:"url"`
+	Category  string         `json:"category"`
+	Resolved  bool           `json:"resolved"`
+	Reason    string         `json:"reason"`
+	Replies   []ReplyComment `json:"replies,omitempty"`
 }
 
 // Analyze classifies and filters review comments, returning unresolved ones (or all if showAll is true).
@@ -220,6 +229,17 @@ func buildResults(data *Data, output *ClassifyOutput, showAll bool) []Unresolved
 			diffHunk = t.Comments[0].DiffHunk
 		}
 
+		// Collect replies (all comments after the first).
+		var replies []ReplyComment
+		for _, rc := range t.Comments[1:] {
+			replies = append(replies, ReplyComment{
+				Author:    rc.Author,
+				Body:      rc.Body,
+				CreatedAt: rc.CreatedAt,
+				URL:       rc.URL,
+			})
+		}
+
 		results = append(results, UnresolvedComment{
 			ThreadID:  t.ID,
 			CommentID: commentID,
@@ -234,6 +254,7 @@ func buildResults(data *Data, output *ClassifyOutput, showAll bool) []Unresolved
 			Category:  category,
 			Resolved:  resolved,
 			Reason:    reason,
+			Replies:   replies,
 		})
 	}
 

--- a/review/review.go
+++ b/review/review.go
@@ -231,13 +231,15 @@ func buildResults(data *Data, output *ClassifyOutput, showAll bool) []Unresolved
 
 		// Collect replies (all comments after the first).
 		var replies []ReplyComment
-		for _, rc := range t.Comments[1:] {
-			replies = append(replies, ReplyComment{
-				Author:    rc.Author,
-				Body:      rc.Body,
-				CreatedAt: rc.CreatedAt,
-				URL:       rc.URL,
-			})
+		if len(t.Comments) > 1 {
+			for _, rc := range t.Comments[1:] {
+				replies = append(replies, ReplyComment{
+					Author:    rc.Author,
+					Body:      rc.Body,
+					CreatedAt: rc.CreatedAt,
+					URL:       rc.URL,
+				})
+			}
 		}
 
 		results = append(results, UnresolvedComment{

--- a/review/review_test.go
+++ b/review/review_test.go
@@ -222,6 +222,88 @@ func TestAnalyzeUnclassifiedDefaultsToResolvedInformational(t *testing.T) {
 	}
 }
 
+func TestAnalyzePopulatesReplies(t *testing.T) {
+	now := time.Now()
+	data := &Data{
+		Threads: []Thread{
+			{
+				ID:   "T1",
+				Path: "main.go",
+				Comments: []Comment{
+					{ID: "C1", Body: "Why is this needed?", Author: "alice", CreatedAt: now, URL: "https://example.com/1"},
+					{ID: "C2", Body: "It handles the edge case for empty input.", Author: "bob", CreatedAt: now.Add(time.Hour), URL: "https://example.com/2"},
+				},
+			},
+		},
+	}
+
+	mock := &mockClassifier{
+		output: &ClassifyOutput{
+			Threads: []ClassifyOutputThread{
+				{ThreadID: "T1", Category: "question", IsResolved: false, Reason: "Unanswered question"},
+			},
+		},
+	}
+
+	results, err := Analyze(context.Background(), data, mock, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	r := results[0]
+	if r.Author != "alice" {
+		t.Errorf("expected author alice, got %s", r.Author)
+	}
+	if r.Body != "Why is this needed?" {
+		t.Errorf("expected first comment body, got %s", r.Body)
+	}
+	if len(r.Replies) != 1 {
+		t.Fatalf("expected 1 reply, got %d", len(r.Replies))
+	}
+	if r.Replies[0].Author != "bob" {
+		t.Errorf("expected reply author bob, got %s", r.Replies[0].Author)
+	}
+	if r.Replies[0].Body != "It handles the edge case for empty input." {
+		t.Errorf("expected reply body, got %s", r.Replies[0].Body)
+	}
+}
+
+func TestAnalyzeNoRepliesForSingleComment(t *testing.T) {
+	data := &Data{
+		Threads: []Thread{
+			{
+				ID:   "T1",
+				Path: "main.go",
+				Comments: []Comment{
+					{ID: "C1", Body: "Fix this", Author: "alice", CreatedAt: time.Now(), URL: "https://example.com/1"},
+				},
+			},
+		},
+	}
+
+	mock := &mockClassifier{
+		output: &ClassifyOutput{
+			Threads: []ClassifyOutputThread{
+				{ThreadID: "T1", Category: "suggestion", IsResolved: false, Reason: "Not fixed"},
+			},
+		},
+	}
+
+	results, err := Analyze(context.Background(), data, mock, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Replies != nil {
+		t.Errorf("expected nil replies for single comment, got %v", results[0].Replies)
+	}
+}
+
 func TestBuildClassifyInput(t *testing.T) {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	line := 42

--- a/skills/triage-pr-reviews/SKILL.md
+++ b/skills/triage-pr-reviews/SKILL.md
@@ -20,10 +20,11 @@ compatibility: Requires gh CLI and gh-pr-reviews extension (gh extension install
    - `commit_id`, `path`, `line`, `diff_hunk` (only for `type: "thread"`): file location and diff context
    - `category`: one of `suggestion`, `nitpick`, `issue`, `question`, `approval`, `informational`
    - `resolved` (bool), `reason` (string): resolution status and rationale
+   - `replies` (array, optional, only for `type: "thread"` with multiple comments): follow-up comments in the thread, each with `author`, `body`, `created_at`, `url`
 2. Check if PR metadata (number, title, url) is already available from conversation context. If not (e.g., when a PR number/URL is explicitly passed as argument), run `gh pr view [arg] --json number,title,url` to get it.
 3. For `type: "thread"` comments, use `path`, `line`, and `diff_hunk` from the JSON response to identify the exact file location. For `type: "comment"` (PR-level), there is no file location.
 4. Check code context for each comment. Leverage any existing conversation context first. Only fetch additional context via `gh pr diff` or file reads when necessary.
-5. Evaluate each comment against the code context. Classify as **Agree**, **Partially Agree**, or **Disagree** with a rationale and suggested action.
+5. Evaluate each comment against the code context. When a thread has `replies`, read the full conversation to understand whether the concern has already been discussed or partially addressed. Classify as **Agree**, **Partially Agree**, or **Disagree** with a rationale and suggested action.
 
 ## Phase 2: Summary Overview
 


### PR DESCRIPTION
## Summary

- Improve the classifier system prompt to explicitly require reading ALL comments in a thread before classification, and treat substantive replies (not just keywords like "fixed"/"done") as evidence of resolution
- Add `replies` field to output (`--json` and terminal markdown) so users can see the full thread conversation without visiting GitHub
- `replies` uses `omitempty`, so single-comment threads produce identical JSON to before (non-breaking)

