### PR TITLE
fix: paginate comments within a review thread

### DIFF
--- a/gh/gh.go
+++ b/gh/gh.go
@@ -27,7 +27,7 @@ func New() (*Client, error) {
 
 type threadCommentNode struct {
 	ID         string
-	DatabaseId int64
+	DatabaseID int64
 	Body       string
 	Author     struct{ Login string }
 	CreatedAt  time.Time
@@ -273,7 +273,7 @@ func (c *Client) fetchRemainingThreadComments(ctx context.Context, threadID stri
 func toComment(n threadCommentNode) review.Comment {
 	return review.Comment{
 		ID:         n.ID,
-		DatabaseID: n.DatabaseId,
+		DatabaseID: n.DatabaseID,
 		Body:       n.Body,
 		Author:     n.Author.Login,
 		CreatedAt:  n.CreatedAt,

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -25,6 +25,27 @@ func New() (*Client, error) {
 	return &Client{v4: v4Client}, nil
 }
 
+type threadCommentNode struct {
+	ID         string
+	DatabaseId int64
+	Body       string
+	Author     struct{ Login string }
+	CreatedAt  time.Time
+	URL        string `graphql:"url"`
+	DiffHunk   string
+	Commit     struct {
+		Oid string
+	}
+}
+
+type threadCommentConnection struct {
+	Nodes    []threadCommentNode
+	PageInfo struct {
+		HasNextPage bool
+		EndCursor   githubv4.String
+	}
+}
+
 type reviewThreadsQuery struct {
 	Repository struct {
 		PullRequest struct {
@@ -35,20 +56,7 @@ type reviewThreadsQuery struct {
 					IsOutdated bool
 					Path       string
 					Line       *int
-					Comments   struct {
-						Nodes []struct {
-							ID         string
-							DatabaseId int64
-							Body       string
-							Author     struct{ Login string }
-							CreatedAt  time.Time
-							URL        string `graphql:"url"`
-							DiffHunk   string
-							Commit     struct {
-								Oid string
-							}
-						}
-					} `graphql:"comments(first: 100)"`
+					Comments   threadCommentConnection `graphql:"comments(first: 100)"`
 				}
 				PageInfo struct {
 					HasNextPage bool
@@ -57,6 +65,17 @@ type reviewThreadsQuery struct {
 			} `graphql:"reviewThreads(first: 100, after: $threadCursor)"`
 		} `graphql:"pullRequest(number: $number)"`
 	} `graphql:"repository(owner: $owner, name: $repo)"`
+}
+
+// threadCommentsQuery pages through a single thread's comments. The thread list
+// query can only ask for a fixed page of comments per thread, so threads with
+// more replies than that need to be topped up one by one via their node ID.
+type threadCommentsQuery struct {
+	Node struct {
+		PullRequestReviewThread struct {
+			Comments threadCommentConnection `graphql:"comments(first: 100, after: $commentCursor)"`
+		} `graphql:"... on PullRequestReviewThread"`
+	} `graphql:"node(id: $threadId)"`
 }
 
 type prCommentsQuery struct {
@@ -134,17 +153,15 @@ func (c *Client) FetchReviews(ctx context.Context, owner, repo string, number in
 				Path:       node.Path,
 				Line:       node.Line,
 			}
-			for _, c := range node.Comments.Nodes {
-				thread.Comments = append(thread.Comments, review.Comment{
-					ID:         c.ID,
-					DatabaseID: c.DatabaseId,
-					Body:       c.Body,
-					Author:     c.Author.Login,
-					CreatedAt:  c.CreatedAt,
-					URL:        c.URL,
-					DiffHunk:   c.DiffHunk,
-					CommitID:   c.Commit.Oid,
-				})
+			for _, cm := range node.Comments.Nodes {
+				thread.Comments = append(thread.Comments, toComment(cm))
+			}
+			if node.Comments.PageInfo.HasNextPage {
+				rest, err := c.fetchRemainingThreadComments(ctx, node.ID, node.Comments.PageInfo.EndCursor)
+				if err != nil {
+					return nil, err
+				}
+				thread.Comments = append(thread.Comments, rest...)
 			}
 			data.Threads = append(data.Threads, thread)
 		}
@@ -225,4 +242,43 @@ func (c *Client) FetchReviews(ctx context.Context, owner, repo string, number in
 	}
 
 	return data, nil
+}
+
+// fetchRemainingThreadComments pages through the comments of a single review
+// thread, starting after cursor.
+func (c *Client) fetchRemainingThreadComments(ctx context.Context, threadID string, cursor githubv4.String) ([]review.Comment, error) {
+	var comments []review.Comment
+	commentCursor := &cursor
+	for {
+		var q threadCommentsQuery
+		variables := map[string]any{
+			"threadId":      githubv4.ID(threadID),
+			"commentCursor": commentCursor,
+		}
+		if err := c.v4.Query(ctx, &q, variables); err != nil {
+			return nil, fmt.Errorf("failed to fetch comments of review thread %s: %w", threadID, err)
+		}
+		conn := q.Node.PullRequestReviewThread.Comments
+		for _, cm := range conn.Nodes {
+			comments = append(comments, toComment(cm))
+		}
+		if !conn.PageInfo.HasNextPage {
+			return comments, nil
+		}
+		next := conn.PageInfo.EndCursor
+		commentCursor = &next
+	}
+}
+
+func toComment(n threadCommentNode) review.Comment {
+	return review.Comment{
+		ID:         n.ID,
+		DatabaseID: n.DatabaseId,
+		Body:       n.Body,
+		Author:     n.Author.Login,
+		CreatedAt:  n.CreatedAt,
+		URL:        n.URL,
+		DiffHunk:   n.DiffHunk,
+		CommitID:   n.Commit.Oid,
+	}
 }


### PR DESCRIPTION
## Summary

- The `reviewThreads` query asked for `comments(first: 100)` per thread but never read that connection's `pageInfo`, so a thread with more than 100 comments silently dropped everything past the first page.
- Threads are the unit this tool reports on: the first comment is the finding, and the replies are the conversation that decides whether it is resolved. Losing the tail of a long thread can flip a resolved thread back to unresolved, and `replies` in the output would be incomplete.
- The inner connection now reports `pageInfo`, and threads that have more comments are topped up through their node ID.

## Changes

- `gh/gh.go` — extract `threadCommentNode` / `threadCommentConnection` so the thread list query and the top-up query share one shape, and add `pageInfo` to the inner `comments` connection
- `gh/gh.go` — add `fetchRemainingThreadComments`, paging a single thread's comments via `node(id:)` + `... on PullRequestReviewThread`
- `gh/gh.go` — extract `toComment` for the node to `review.Comment` conversion now used by both paths

## Design notes

- **Warning instead of fetching was the cheaper option, and was rejected.** Adding `pageInfo` alone would let the tool report that it truncated, but the truncation is invisible to the user and there is no action they could take with the warning. Fetching the rest is the only outcome that makes the report correct.
- **No extra requests for ordinary PRs.** The top-up query only fires for threads whose `hasNextPage` is true, so a PR with normal-length threads issues exactly the same requests as before.

## Test plan

- [x] `make test`
- [x] `make lint` — 0 issues
- [x] Exercised the new pagination path against a live PR. Since 100+ comment threads do not occur naturally here, the page size was temporarily lowered to `first: 1` and run against #68: the result was identical to `first: 100` (4 threads, 2 comments each, 8 total), confirming the `node(id:)` query shape and the cursor loop both work. The page size was then restored.