### PR TITLE
fix: split large classifier inputs

### DIFF
--- a/review/copilot.go
+++ b/review/copilot.go
@@ -14,6 +14,11 @@ import (
 
 const minCopilotVersion = "1.0.51"
 
+// Keep enough room for the system prompt and the model's response. The SDK
+// prompt limit is model-dependent, so use a conservative serialized-input
+// limit and split larger requests into multiple calls.
+const maxClassifyInputBytes = 100 * 1024
+
 const systemPrompt = `You are a code review comment classifier. You analyze PR review comments and classify each one.
 
 IMPORTANT: Each thread contains a "comments" array listing the full conversation in chronological order. The first comment is the original review comment; subsequent comments are replies. You MUST read ALL comments in every thread before classifying. The conversation flow is critical for determining resolution status.
@@ -89,6 +94,26 @@ func NewCopilotClassifier(ctx context.Context, model string) (*CopilotClassifier
 
 // ClassifyAll sends all review data to Copilot and returns classification results.
 func (c *CopilotClassifier) ClassifyAll(ctx context.Context, input *ClassifyInput) (*ClassifyOutput, error) {
+	chunks, err := splitClassifyInput(input, maxClassifyInputBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := &ClassifyOutput{}
+	for _, chunk := range chunks {
+		output, err := c.classifyChunk(ctx, chunk)
+		if err != nil {
+			return nil, err
+		}
+		merged.Threads = append(merged.Threads, output.Threads...)
+		merged.PRComments = append(merged.PRComments, output.PRComments...)
+		merged.Suppressed = append(merged.Suppressed, output.Suppressed...)
+	}
+
+	return merged, nil
+}
+
+func (c *CopilotClassifier) classifyChunk(ctx context.Context, input *ClassifyInput) (*ClassifyOutput, error) {
 	inputJSON, err := json.Marshal(input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal classify input: %w", err)
@@ -142,6 +167,81 @@ func (c *CopilotClassifier) ClassifyAll(ctx context.Context, input *ClassifyInpu
 	}
 
 	return output, nil
+}
+
+// splitClassifyInput groups complete entries into requests below maxBytes.
+// A thread is kept intact so the model always sees its complete conversation.
+func splitClassifyInput(input *ClassifyInput, maxBytes int) ([]*ClassifyInput, error) {
+	if maxBytes <= 0 {
+		return nil, fmt.Errorf("classify input size limit must be positive")
+	}
+
+	chunks := make([]*ClassifyInput, 0, 1)
+	current := &ClassifyInput{}
+
+	flush := func() {
+		if len(current.Threads) == 0 && len(current.PRComments) == 0 && len(current.Suppressed) == 0 {
+			return
+		}
+		chunks = append(chunks, current)
+		current = &ClassifyInput{}
+	}
+
+	tryAdd := func(add func(*ClassifyInput)) error {
+		candidate := cloneClassifyInput(current)
+		add(candidate)
+		encoded, err := json.Marshal(candidate)
+		if err != nil {
+			return fmt.Errorf("failed to marshal classify input chunk: %w", err)
+		}
+		if len(encoded) > maxBytes {
+			if len(current.Threads) == 0 && len(current.PRComments) == 0 && len(current.Suppressed) == 0 {
+				return fmt.Errorf("a single review comment exceeds the classify input size limit of %d bytes", maxBytes)
+			}
+			flush()
+			candidate = cloneClassifyInput(current)
+			add(candidate)
+			encoded, err = json.Marshal(candidate)
+			if err != nil {
+				return fmt.Errorf("failed to marshal classify input chunk: %w", err)
+			}
+			if len(encoded) > maxBytes {
+				return fmt.Errorf("a single review comment exceeds the classify input size limit of %d bytes", maxBytes)
+			}
+		}
+		*current = *candidate
+		return nil
+	}
+
+	for _, thread := range input.Threads {
+		thread := thread
+		if err := tryAdd(func(chunk *ClassifyInput) { chunk.Threads = append(chunk.Threads, thread) }); err != nil {
+			return nil, err
+		}
+	}
+	for _, comment := range input.PRComments {
+		comment := comment
+		if err := tryAdd(func(chunk *ClassifyInput) { chunk.PRComments = append(chunk.PRComments, comment) }); err != nil {
+			return nil, err
+		}
+	}
+	for _, comment := range input.Suppressed {
+		comment := comment
+		if err := tryAdd(func(chunk *ClassifyInput) { chunk.Suppressed = append(chunk.Suppressed, comment) }); err != nil {
+			return nil, err
+		}
+	}
+	flush()
+
+	return chunks, nil
+}
+
+func cloneClassifyInput(input *ClassifyInput) *ClassifyInput {
+	return &ClassifyInput{
+		Threads:    append([]ClassifyInputThread(nil), input.Threads...),
+		PRComments: append([]ClassifyInputPRComment(nil), input.PRComments...),
+		Suppressed: append([]ClassifyInputSuppressed(nil), input.Suppressed...),
+	}
 }
 
 // Close shuts down the Copilot session and client.

--- a/review/copilot.go
+++ b/review/copilot.go
@@ -113,62 +113,6 @@ func (c *CopilotClassifier) ClassifyAll(ctx context.Context, input *ClassifyInpu
 	return merged, nil
 }
 
-func (c *CopilotClassifier) classifyChunk(ctx context.Context, input *ClassifyInput) (*ClassifyOutput, error) {
-	inputJSON, err := json.Marshal(input)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal classify input: %w", err)
-	}
-
-	var responseContent string
-	done := make(chan struct{})
-	var eventErr error
-
-	unsubscribe := c.session.On(func(event copilot.SessionEvent) {
-		switch event.Type() {
-		case copilot.SessionEventTypeAssistantMessage:
-			if d, ok := event.Data.(*copilot.AssistantMessageData); ok {
-				responseContent = d.Content
-			}
-		case copilot.SessionEventTypeSessionIdle:
-			close(done)
-		case copilot.SessionEventTypeSessionError:
-			if d, ok := event.Data.(*copilot.SessionErrorData); ok {
-				eventErr = fmt.Errorf("copilot error: %s", d.Message)
-			}
-			select {
-			case <-done:
-			default:
-				close(done)
-			}
-		}
-	})
-	defer unsubscribe()
-
-	_, err = c.session.Send(ctx, copilot.MessageOptions{
-		Prompt: string(inputJSON),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to send message to copilot: %w", err)
-	}
-
-	select {
-	case <-done:
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
-
-	if eventErr != nil {
-		return nil, eventErr
-	}
-
-	output, err := parseClassifyOutput(responseContent)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse copilot response: %w", err)
-	}
-
-	return output, nil
-}
-
 // splitClassifyInput groups complete entries into requests below maxBytes.
 // A thread is kept intact so the model always sees its complete conversation.
 func splitClassifyInput(input *ClassifyInput, maxBytes int) ([]*ClassifyInput, error) {
@@ -252,6 +196,62 @@ func (c *CopilotClassifier) Close() {
 	if c.client != nil {
 		c.client.Stop() //nolint:errcheck
 	}
+}
+
+func (c *CopilotClassifier) classifyChunk(ctx context.Context, input *ClassifyInput) (*ClassifyOutput, error) {
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal classify input: %w", err)
+	}
+
+	var responseContent string
+	done := make(chan struct{})
+	var eventErr error
+
+	unsubscribe := c.session.On(func(event copilot.SessionEvent) {
+		switch event.Type() {
+		case copilot.SessionEventTypeAssistantMessage:
+			if d, ok := event.Data.(*copilot.AssistantMessageData); ok {
+				responseContent = d.Content
+			}
+		case copilot.SessionEventTypeSessionIdle:
+			close(done)
+		case copilot.SessionEventTypeSessionError:
+			if d, ok := event.Data.(*copilot.SessionErrorData); ok {
+				eventErr = fmt.Errorf("copilot error: %s", d.Message)
+			}
+			select {
+			case <-done:
+			default:
+				close(done)
+			}
+		}
+	})
+	defer unsubscribe()
+
+	_, err = c.session.Send(ctx, copilot.MessageOptions{
+		Prompt: string(inputJSON),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to send message to copilot: %w", err)
+	}
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	if eventErr != nil {
+		return nil, eventErr
+	}
+
+	output, err := parseClassifyOutput(responseContent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse copilot response: %w", err)
+	}
+
+	return output, nil
 }
 
 func checkCopilotCLI() error {

--- a/review/copilot_test.go
+++ b/review/copilot_test.go
@@ -1,8 +1,72 @@
 package review
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 )
+
+func TestSplitClassifyInput(t *testing.T) {
+	line := 10
+	input := &ClassifyInput{
+		Threads: []ClassifyInputThread{
+			{ThreadID: "T1", Comments: []ClassifyInputComment{{Body: strings.Repeat("a", 40)}}},
+			{ThreadID: "T2", Comments: []ClassifyInputComment{{Body: strings.Repeat("b", 40)}}},
+		},
+		PRComments: []ClassifyInputPRComment{{ID: "P1", Body: strings.Repeat("c", 40)}},
+		Suppressed: []ClassifyInputSuppressed{{ID: "S1", Path: "file.go", Line: &line, Body: strings.Repeat("d", 40)}},
+	}
+
+	chunks, err := splitClassifyInput(input, 250)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected input to be split, got %d chunk(s)", len(chunks))
+	}
+
+	var threadIDs, commentIDs, suppressedIDs []string
+	for _, chunk := range chunks {
+		encoded, err := json.Marshal(chunk)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(encoded) > 250 {
+			t.Errorf("chunk is %d bytes, want at most 250", len(encoded))
+		}
+		for _, thread := range chunk.Threads {
+			threadIDs = append(threadIDs, thread.ThreadID)
+		}
+		for _, comment := range chunk.PRComments {
+			commentIDs = append(commentIDs, comment.ID)
+		}
+		for _, comment := range chunk.Suppressed {
+			suppressedIDs = append(suppressedIDs, comment.ID)
+		}
+	}
+	if got, want := strings.Join(threadIDs, ","), "T1,T2"; got != want {
+		t.Errorf("thread IDs = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(commentIDs, ","), "P1"; got != want {
+		t.Errorf("comment IDs = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(suppressedIDs, ","), "S1"; got != want {
+		t.Errorf("suppressed IDs = %q, want %q", got, want)
+	}
+}
+
+func TestSplitClassifyInputRejectsOversizedEntry(t *testing.T) {
+	input := &ClassifyInput{
+		Threads: []ClassifyInputThread{{
+			ThreadID: "T1",
+			Comments: []ClassifyInputComment{{Body: strings.Repeat("a", 100)}},
+		}},
+	}
+
+	if _, err := splitClassifyInput(input, 50); err == nil {
+		t.Fatal("expected oversized entry error")
+	}
+}
 
 func TestParseClassifyOutput(t *testing.T) {
 	tests := []struct {
@@ -29,7 +93,7 @@ func TestParseClassifyOutput(t *testing.T) {
 		},
 		{
 			name: "markdown fenced JSON",
-			raw: "```json\n{\"threads\":[],\"pr_comments\":[{\"id\":\"PC1\",\"category\":\"question\",\"is_resolved\":true,\"reason\":\"answered\"}]}\n```",
+			raw:  "```json\n{\"threads\":[],\"pr_comments\":[{\"id\":\"PC1\",\"category\":\"question\",\"is_resolved\":true,\"reason\":\"answered\"}]}\n```",
 			check: func(t *testing.T, o *ClassifyOutput) {
 				t.Helper()
 				if len(o.PRComments) != 1 {


### PR DESCRIPTION
## Summary

Large pull requests can exceed the model input limit when all review comments are sent in one JSON payload. Split oversized classifier requests while preserving complete thread conversations, then merge the classification results into one output.

## Changes

- Split serialized classifier input into requests of up to 100 KiB.
- Keep each inline thread and its full comment conversation together.
- Merge `threads`, `pr_comments`, and `suppressed_comments` results from each model response.
- Return an explicit error when a single review entry exceeds the limit.
- Add tests for chunk sizing, entry preservation, and oversized entries.

## Design notes

- The split boundary is a complete review entry rather than an individual comment, because resolution classification depends on reading the entire thread conversation.
- Requests are processed sequentially using the existing Copilot session, so the output remains a single classification result for `Analyze`.