### PR TITLE
fix: exclude GitHub-resolved threads from the classifier input

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Only `suggestion`, `nitpick`, `issue`, and `question` categories are evaluated f
 
 Resolution status is determined by combining GitHub's native thread resolution state with Copilot-based analysis:
 
-1. **GitHub-resolved threads** — If a review thread is marked as resolved on GitHub (via the "Resolve conversation" button), it is always treated as **resolved**, regardless of Copilot's analysis. PR-level comments have no GitHub resolution state, so this step only applies to inline review threads.
+1. **GitHub-resolved threads** — If a review thread is marked as resolved on GitHub (via the "Resolve conversation" button), it is always treated as **resolved**. Such threads are excluded from the Copilot request entirely, so they carry no category or reason and are reported as `informational` when `-a` is given. PR-level comments have no GitHub resolution state, so this step only applies to inline review threads.
 2. **Copilot analysis** — For threads not resolved on GitHub and for PR-level comments, Copilot classifies the comment category and determines resolution. As part of this analysis, `approval` and `informational` categories are always treated as resolved. For `suggestion`, `nitpick`, `issue`, and `question` categories, Copilot examines follow-up comments for evidence that the feedback was addressed or the question was answered.
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Only `suggestion`, `nitpick`, `issue`, and `question` categories are evaluated f
 
 Resolution status is determined by combining GitHub's native thread resolution state with Copilot-based analysis:
 
-1. **GitHub-resolved threads** — If a review thread is marked as resolved on GitHub (via the "Resolve conversation" button), it is always treated as **resolved**. Such threads are excluded from the Copilot request entirely, so they carry no category or reason and are reported as `informational` when `-a` is given. PR-level comments have no GitHub resolution state, so this step only applies to inline review threads.
+1. **GitHub-resolved threads** — If a review thread is marked as resolved on GitHub (via the "Resolve conversation" button), it is always treated as **resolved**. Such threads are excluded from the Copilot request entirely, so they have no classified category. With `-a` they are reported as `informational` with the fixed reason `marked as resolved on GitHub`. PR-level comments have no GitHub resolution state, so this step only applies to inline review threads.
 2. **Copilot analysis** — For threads not resolved on GitHub and for PR-level comments, Copilot classifies the comment category and determines resolution. As part of this analysis, `approval` and `informational` categories are always treated as resolved. For `suggestion`, `nitpick`, `issue`, and `question` categories, Copilot examines follow-up comments for evidence that the feedback was addressed or the question was answered.
 
 ```mermaid

--- a/review/copilot.go
+++ b/review/copilot.go
@@ -36,7 +36,6 @@ For each comment or thread, determine:
    - For threads with multiple comments, you MUST analyze the ENTIRE conversation to determine resolution:
      - For "suggestion", "nitpick", and "issue": A reply from the PR author acknowledging the feedback (e.g., "fixed", "done", "updated", explaining the change, or providing a valid justification for the current approach) indicates resolution.
      - For "question": Any substantive reply that answers the question indicates resolution. This includes explanations, clarifications, or references to relevant context. A question that has received a meaningful answer MUST be marked as resolved.
-   - If is_resolved_on_github is true, always consider it resolved regardless of comment content.
    - Only set is_resolved to false when there is NO meaningful reply addressing the concern, or when there is an ongoing unresolved disagreement after the latest reply.
 
 3. **reason**: Brief explanation of your classification and resolution decision. When a thread has multiple comments, reference the relevant reply that influenced your decision.

--- a/review/review.go
+++ b/review/review.go
@@ -37,12 +37,11 @@ type Data struct {
 
 // ClassifyInputThread is a thread entry sent to the classifier.
 type ClassifyInputThread struct {
-	ThreadID           string                 `json:"thread_id"`
-	Type               string                 `json:"type"`
-	Path               string                 `json:"path,omitempty"`
-	Line               *int                   `json:"line,omitempty"`
-	IsResolvedOnGitHub bool                   `json:"is_resolved_on_github"`
-	Comments           []ClassifyInputComment `json:"comments"`
+	ThreadID string                 `json:"thread_id"`
+	Type     string                 `json:"type"`
+	Path     string                 `json:"path,omitempty"`
+	Line     *int                   `json:"line,omitempty"`
+	Comments []ClassifyInputComment `json:"comments"`
 }
 
 // ClassifyInputComment is a comment entry sent to the classifier.
@@ -163,12 +162,16 @@ func buildClassifyInput(data *Data, suppressed []SuppressedComment) *ClassifyInp
 	input := &ClassifyInput{}
 
 	for _, t := range data.Threads {
+		// Threads resolved on GitHub are forced resolved below, so classifying
+		// them would only inflate the single Copilot request.
+		if t.IsResolved {
+			continue
+		}
 		ct := ClassifyInputThread{
-			ThreadID:           t.ID,
-			Type:               "inline",
-			Path:               t.Path,
-			Line:               t.Line,
-			IsResolvedOnGitHub: t.IsResolved,
+			ThreadID: t.ID,
+			Type:     "inline",
+			Path:     t.Path,
+			Line:     t.Line,
 		}
 		for _, c := range t.Comments {
 			ct.Comments = append(ct.Comments, ClassifyInputComment{
@@ -235,6 +238,10 @@ func normalizeResolved(category string, resolved bool) bool {
 // review is reported as resolved.
 const supersededReason = "not listed in the latest Copilot review, so it is superseded"
 
+// resolvedOnGitHubReason explains why a thread resolved on GitHub is reported
+// as resolved without a classification.
+const resolvedOnGitHubReason = "marked as resolved on GitHub"
+
 // unclassifiedReason explains why a suppressed comment the classifier did not
 // return a result for is reported as unresolved.
 const unclassifiedReason = "the classifier returned no result for this comment, so it is reported as unresolved"
@@ -248,18 +255,18 @@ func buildResults(data *Data, suppressed []SuppressedComment, output *ClassifyOu
 	}
 
 	for _, t := range data.Threads {
-		classified, ok := threadMap[t.ID]
 		resolved := t.IsResolved
 		category := defaultCategory
 		reason := ""
-		classifiedResolved := false
-		if ok {
+		switch classified, ok := threadMap[t.ID]; {
+		case t.IsResolved:
+			reason = resolvedOnGitHubReason
+		case ok:
 			category = normalizeCategory(classified.Category)
 			reason = classified.Reason
-			classifiedResolved = classified.IsResolved
-		}
-		if !resolved {
-			resolved = normalizeResolved(category, classifiedResolved)
+			resolved = normalizeResolved(category, classified.IsResolved)
+		default:
+			resolved = normalizeResolved(category, false)
 		}
 
 		if !showAll && resolved {

--- a/review/review_test.go
+++ b/review/review_test.go
@@ -166,6 +166,25 @@ func TestAnalyzeGitHubResolvedOverrides(t *testing.T) {
 	if len(results) != 0 {
 		t.Errorf("expected 0 results (GitHub resolved overrides), got %d", len(results))
 	}
+
+	// With showAll=true, the thread is still reported, but as resolved on GitHub
+	// rather than with the classifier result.
+	results, err = Analyze(context.Background(), data, mock, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result with showAll, got %d", len(results))
+	}
+	if !results[0].Resolved {
+		t.Error("expected resolved to be true")
+	}
+	if results[0].Category != "informational" {
+		t.Errorf("expected category informational, got %s", results[0].Category)
+	}
+	if results[0].Reason != resolvedOnGitHubReason {
+		t.Errorf("expected reason %q, got %q", resolvedOnGitHubReason, results[0].Reason)
+	}
 }
 
 func TestAnalyzeUnclassifiedDefaultsToResolvedInformational(t *testing.T) {
@@ -318,6 +337,14 @@ func TestBuildClassifyInput(t *testing.T) {
 					{ID: "C1", Body: "Fix this", Author: "alice", CreatedAt: now},
 				},
 			},
+			{
+				ID:         "T2",
+				IsResolved: true,
+				Path:       "main.go",
+				Comments: []Comment{
+					{ID: "C2", Body: "Already handled", Author: "alice", CreatedAt: now},
+				},
+			},
 		},
 		PRComments: []Comment{
 			{ID: "PC1", Body: "Overall", Author: "bob", CreatedAt: now},
@@ -336,9 +363,6 @@ func TestBuildClassifyInput(t *testing.T) {
 	}
 	if input.Threads[0].ThreadID != "T1" {
 		t.Errorf("expected thread ID T1, got %s", input.Threads[0].ThreadID)
-	}
-	if input.Threads[0].IsResolvedOnGitHub {
-		t.Error("expected IsResolvedOnGitHub to be false")
 	}
 	if input.Threads[0].Type != "inline" {
 		t.Errorf("expected type inline, got %s", input.Threads[0].Type)


### PR DESCRIPTION
## Summary

- A review thread marked as resolved on GitHub is always treated as resolved, whatever the classifier says. It was still sent to Copilot in full, with `is_resolved_on_github: true` and the prompt instructing the model to force the verdict, so the request carried the body and every reply of threads whose answer was already known.
- Suppressed comments superseded by a newer Copilot review were already dropped from the payload for exactly this reason. Threads were the remaining case.
- They are dropped from the classifier input and still reported in the output under `-a`.

## Changes

- `review/review.go` — skip `t.IsResolved` threads in `buildClassifyInput`, and drop `ClassifyInputThread.IsResolvedOnGitHub`, which can no longer be true
- `review/review.go` — rewrite the thread branch of `buildResults` as a switch so the GitHub-resolved case is handled before any classifier lookup, reporting the new `resolvedOnGitHubReason`
- `review/copilot.go` — remove the prompt line about `is_resolved_on_github`, which now describes a field the model never receives
- README — note that these threads never reach Copilot and how they surface under `-a`

## Design notes

- **Keeping the field and letting the prompt force the verdict was the smaller diff, and was rejected.** The verdict is decided before the request is composed, so paying tokens to have the model repeat it buys nothing. On a PR with a long history of resolved conversations, this is most of the payload.
- **The category is lost, and that is the trade.** An unclassified thread falls back to `informational`, so under `-a` these threads read as `informational` with a fixed reason rather than carrying the category they would have been given. Classifying them purely to label output that is hidden by default is the cost this change is removing.